### PR TITLE
Redesign install.sh onboarding to be repo-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ wt help
 ```
 
 The installer will:
-1. Copy the toolkit to `~/.config/wt/`
+1. Copy the toolkit to `~/.wt/`
 2. Add sourcing to your shell rc file
 3. Prompt for workspace paths (main repo, worktrees, metadata vault)
 4. Create required directories
@@ -196,26 +196,26 @@ To set it up manually:
 
 ```bash
 # Create log directory
-mkdir -p ~/.config/wt/logs
+mkdir -p ~/.wt/logs
 
 # Edit crontab
 crontab -e
 
 # Add this line to run nightly at 2am (uses login shell for full PATH):
-0 2 * * * /bin/zsh -lc '~/.config/wt/lib/wt-ijwb-refresh' >> ~/.config/wt/logs/ijwb-refresh.log 2>&1
+0 2 * * * /bin/zsh -lc '~/.wt/lib/wt-ijwb-refresh' >> ~/.wt/logs/ijwb-refresh.log 2>&1
 ```
 
 You can also run the script manually:
 
 ```bash
 # Refresh all .ijwb directories and re-export to vault
-~/.config/wt/lib/wt-ijwb-refresh
+~/.wt/lib/wt-ijwb-refresh
 
 # Preview what would be refreshed (dry run)
-~/.config/wt/lib/wt-ijwb-refresh --dry-run
+~/.wt/lib/wt-ijwb-refresh --dry-run
 
 # Refresh targets files only (skip re-export step)
-~/.config/wt/lib/wt-ijwb-refresh --no-export
+~/.wt/lib/wt-ijwb-refresh --no-export
 ```
 
 The refresh script:

--- a/bin/wt-add
+++ b/bin/wt-add
@@ -71,8 +71,8 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 # Bootstrap: source wt-common from lib/
 if [[ -f "$LIB_DIR/wt-common" ]]; then
   . "$LIB_DIR/wt-common"
-elif [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+elif [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 else
   echo "Error: Cannot find wt-common" >&2
   exit 1

--- a/bin/wt-cd
+++ b/bin/wt-cd
@@ -34,8 +34,8 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 # Bootstrap: source wt-common from lib/
 if [[ -f "$LIB_DIR/wt-common" ]]; then
   . "$LIB_DIR/wt-common"
-elif [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+elif [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 else
   echo "Error: Cannot find wt-common" >&2
   exit 1

--- a/bin/wt-ijwb-export
+++ b/bin/wt-ijwb-export
@@ -62,8 +62,8 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 # Bootstrap: source wt-common from lib/
 if [[ -f "$LIB_DIR/wt-common" ]]; then
   . "$LIB_DIR/wt-common"
-elif [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+elif [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 else
   echo "Error: Cannot find wt-common" >&2
   exit 1

--- a/bin/wt-ijwb-import
+++ b/bin/wt-ijwb-import
@@ -70,8 +70,8 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 # Bootstrap: source wt-common from lib/
 if [[ -f "$LIB_DIR/wt-common" ]]; then
   . "$LIB_DIR/wt-common"
-elif [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+elif [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 else
   echo "Error: Cannot find wt-common" >&2
   exit 1

--- a/bin/wt-list
+++ b/bin/wt-list
@@ -36,8 +36,8 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 # Bootstrap: source wt-common from lib/
 if [[ -f "$LIB_DIR/wt-common" ]]; then
   . "$LIB_DIR/wt-common"
-elif [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+elif [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 else
   echo "Error: Cannot find wt-common" >&2
   exit 1

--- a/bin/wt-remove
+++ b/bin/wt-remove
@@ -40,8 +40,8 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 # Bootstrap: source wt-common from lib/
 if [[ -f "$LIB_DIR/wt-common" ]]; then
   . "$LIB_DIR/wt-common"
-elif [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+elif [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 else
   echo "Error: Cannot find wt-common" >&2
   exit 1

--- a/bin/wt-switch
+++ b/bin/wt-switch
@@ -42,8 +42,8 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 # Bootstrap: source wt-common from lib/
 if [[ -f "$LIB_DIR/wt-common" ]]; then
   . "$LIB_DIR/wt-common"
-elif [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+elif [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 else
   echo "Error: Cannot find wt-common" >&2
   exit 1

--- a/completion/wt.bash
+++ b/completion/wt.bash
@@ -26,13 +26,13 @@
 #
 # Usage:
 #   1. Place this file as: completion/wt.bash
-#   2. Have install.sh copy it into ~/.config/wt/wt.bash
+#   2. Have install.sh copy it into ~/.wt/wt.bash
 #   3. In ~/.bashrc (or ~/.bash_profile), add:
-#        [[ -f "$HOME/.config/wt/wt.bash" ]] && source "$HOME/.config/wt/wt.bash"
+#        [[ -f "$HOME/.wt/wt.bash" ]] && source "$HOME/.wt/wt.bash"
 
 # --- Load shared config (wt-common) if available ---
-if [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+if [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 fi
 
 # --- Helper: resolve which repo to use for branch completion ---

--- a/completion/wt.zsh
+++ b/completion/wt.zsh
@@ -22,8 +22,8 @@
 # This file is designed for personal use.
 
 # --- Load shared config (wt-common) if available ---
-if [[ -r "$HOME/.config/wt/lib/wt-common" ]]; then
-  source "$HOME/.config/wt/lib/wt-common"
+if [[ -r "$HOME/.wt/lib/wt-common" ]]; then
+  source "$HOME/.wt/lib/wt-common"
 fi
 
 # --- Helper: resolve which repo to use for branch completion ---

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# install.sh — Install worktree-toolkit to ~/.config/wt/
-# ======================================================
+# install.sh — Install worktree-toolkit to ~/.wt/
+# ================================================
 #
 # This script:
-#   1. Copies the toolkit to ~/.config/wt/
+#   1. Copies the toolkit to ~/.wt/
 #   2. Adds source line to ~/.zshrc or ~/.bashrc
 #   3. Optionally configures environment variables in lib/wt-common
 #   4. Creates required directories
@@ -20,7 +20,7 @@ set -euo pipefail
 # ═══════════════════════════════════════════════════════════════════════════════
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-INSTALL_DIR="$HOME/.config/wt"
+INSTALL_DIR="$HOME/.wt"
 
 # Source wt-common to get default values and color helpers
 . "$SOURCE_DIR/lib/wt-common"
@@ -58,6 +58,71 @@ prompt_with_default() {
   echo "${result:-$default}"
 }
 
+# Expand ~ to $HOME in a path
+expand_path() {
+  local path="$1"
+  # Expand ~ at the beginning of the path (e.g., ~/foo -> /home/user/foo)
+  case "$path" in
+    "~")
+      echo "$HOME"
+      ;;
+    "~/"*)
+      echo "${HOME}${path#\~}"
+      ;;
+    *)
+      echo "$path"
+      ;;
+  esac
+}
+
+# Detect the default branch for a repository
+# Tries: origin/HEAD, then common branch names
+detect_default_branch() {
+  local repo="$1"
+
+  # Try to get from origin/HEAD
+  local default_branch
+  default_branch=$(git -C "$repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+
+  if [[ -n "$default_branch" ]]; then
+    echo "$default_branch"
+    return 0
+  fi
+
+  # Check for common default branch names
+  for branch in main master; do
+    if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null || \
+       git -C "$repo" show-ref --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null; then
+      echo "$branch"
+      return 0
+    fi
+  done
+
+  # Fallback to main
+  echo "main"
+}
+
+# Derive all paths from the repository location
+# Sets: WT_MAIN_REPO_ROOT, WT_WORKTREES_BASE, WT_ACTIVE_WORKTREE, WT_IDEA_FILES_BASE
+derive_paths_from_repo() {
+  local repo="$1"
+  local repo_name
+
+  repo_name="$(basename "$repo")"
+
+  # The current repo location becomes the symlink location
+  WT_ACTIVE_WORKTREE="$repo"
+
+  # All worktree data goes to ~/.wt/repos/<name>/
+  WT_MAIN_REPO_ROOT="$HOME/.wt/repos/${repo_name}/base"
+
+  # Worktrees directory
+  WT_WORKTREES_BASE="$HOME/.wt/repos/${repo_name}/worktrees"
+
+  # IntelliJ metadata
+  WT_IDEA_FILES_BASE="$HOME/.wt/repos/${repo_name}/idea-files"
+}
+
 # Copy toolkit to installation directory
 install_toolkit() {
   echo "Installing worktree-toolkit to $INSTALL_DIR ..."
@@ -82,7 +147,7 @@ install_toolkit() {
 
 # Configure shell rc files to source wt.sh
 configure_shell_rc() {
-  local source_line='[[ -f "$HOME/.config/wt/wt.sh" ]] && source "$HOME/.config/wt/wt.sh"'
+  local source_line='[[ -f "$HOME/.wt/wt.sh" ]] && source "$HOME/.wt/wt.sh"'
 
   echo "Configuring shell..."
 
@@ -96,7 +161,7 @@ configure_shell_rc() {
 }
 
 # Prompt user for configuration and write to wt-common
-# Note: WT_* variables are already set with defaults from wt-common
+# Uses a user-centric flow: start with which repo to manage, then derive paths
 configure_wt_common() {
   local wt_common="$INSTALL_DIR/lib/wt-common"
 
@@ -105,26 +170,120 @@ configure_wt_common() {
     return 1
   fi
 
-  echo "Configure your worktree environment. Press Enter to accept defaults."
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 1: Ask which repository to manage
+  # ─────────────────────────────────────────────────────────────────────────────
+  echo "Which repository do you want to manage with worktrees?"
+  echo
+  echo "Enter the path to your existing git repository."
+  echo "Example: ~/Development/myrepo"
   echo
 
-  WT_MAIN_REPO_ROOT=$(prompt_with_default "Main repository root" "$WT_MAIN_REPO_ROOT")
-  WT_WORKTREES_BASE=$(prompt_with_default "Worktrees base directory" "$WT_WORKTREES_BASE")
-  WT_IDEA_FILES_BASE=$(prompt_with_default "IntelliJ metadata directory" "$WT_IDEA_FILES_BASE")
-  WT_ACTIVE_WORKTREE=$(prompt_with_default "Active worktree symlink" "$WT_ACTIVE_WORKTREE")
-  WT_BASE_BRANCH=$(prompt_with_default "Default base branch" "$WT_BASE_BRANCH")
+  local repo_path
+  while true; do
+    if ! read -rp "Repository path: " repo_path; then
+      echo
+      exit 1
+    fi
+
+    # Handle empty input
+    if [[ -z "$repo_path" ]]; then
+      echo "Please enter a repository path."
+      continue
+    fi
+
+    # Expand ~ to $HOME
+    repo_path=$(expand_path "$repo_path")
+
+    # Validate it exists
+    if [[ ! -d "$repo_path" ]]; then
+      error "Directory not found: $repo_path"
+      continue
+    fi
+
+    # Validate it's a git repository
+    if ! git -C "$repo_path" rev-parse --git-dir &>/dev/null; then
+      error "Not a git repository: $repo_path"
+      continue
+    fi
+
+    break
+  done
+
+  # Normalize to absolute path
+  repo_path="$(cd "$repo_path" && pwd)"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 2: Auto-detect git info and show confirmation
+  # ─────────────────────────────────────────────────────────────────────────────
+  echo
+  echo "Detected repository:"
+  echo "  Path:   $repo_path"
+
+  # Get remote origin URL if available
+  local remote_url
+  remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null || echo "(no remote)")
+  echo "  Remote: $remote_url"
+
+  # Detect default branch
+  WT_BASE_BRANCH=$(detect_default_branch "$repo_path")
+  echo "  Branch: $WT_BASE_BRANCH (default branch)"
 
   echo
-  echo "Configuration:"
-  echo "  WT_MAIN_REPO_ROOT:   $WT_MAIN_REPO_ROOT"
-  echo "  WT_WORKTREES_BASE:   $WT_WORKTREES_BASE"
-  echo "  WT_IDEA_FILES_BASE:  $WT_IDEA_FILES_BASE"
-  echo "  WT_ACTIVE_WORKTREE:  $WT_ACTIVE_WORKTREE"
-  echo "  WT_BASE_BRANCH:      $WT_BASE_BRANCH"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 3: Derive paths automatically
+  # ─────────────────────────────────────────────────────────────────────────────
+  derive_paths_from_repo "$repo_path"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Step 4: Show derived configuration and allow edits
+  # ─────────────────────────────────────────────────────────────────────────────
+  echo "Derived configuration:"
   echo
+  echo "  The worktree toolkit will set up the following structure:"
+  echo
+  echo "  ${BOLD}Active symlink:${NC}      $WT_ACTIVE_WORKTREE"
+  echo "     Your IDE opens this path. It's a symlink that can point to any worktree."
+  echo
+  echo "  ${BOLD}Main repository:${NC}     $WT_MAIN_REPO_ROOT"
+  echo "     Your current repo will be moved here (the \"master\" worktree)."
+  echo
+  echo "  ${BOLD}Worktrees directory:${NC} $WT_WORKTREES_BASE"
+  echo "     New worktrees will be created here."
+  echo
+  echo "  ${BOLD}IntelliJ metadata:${NC}   $WT_IDEA_FILES_BASE"
+  echo "     Shared .ijwb files for instant project switching."
+  echo
+  echo "  ${BOLD}Default branch:${NC}      $WT_BASE_BRANCH"
+  echo "     Used when creating new worktrees."
+  echo
+
+  if prompt_confirm "Use this configuration? [Y/n]" "y"; then
+    : # Continue with derived values
+  else
+    echo
+    echo "You can customize each value. Press Enter to keep the default."
+    echo
+
+    WT_ACTIVE_WORKTREE=$(prompt_with_default "Active symlink path" "$WT_ACTIVE_WORKTREE")
+    WT_MAIN_REPO_ROOT=$(prompt_with_default "Main repository path" "$WT_MAIN_REPO_ROOT")
+    WT_WORKTREES_BASE=$(prompt_with_default "Worktrees directory" "$WT_WORKTREES_BASE")
+    WT_IDEA_FILES_BASE=$(prompt_with_default "IntelliJ metadata directory" "$WT_IDEA_FILES_BASE")
+    WT_BASE_BRANCH=$(prompt_with_default "Default base branch" "$WT_BASE_BRANCH")
+
+    echo
+    echo "Final configuration:"
+    echo "  WT_ACTIVE_WORKTREE:  $WT_ACTIVE_WORKTREE"
+    echo "  WT_MAIN_REPO_ROOT:   $WT_MAIN_REPO_ROOT"
+    echo "  WT_WORKTREES_BASE:   $WT_WORKTREES_BASE"
+    echo "  WT_IDEA_FILES_BASE:  $WT_IDEA_FILES_BASE"
+    echo "  WT_BASE_BRANCH:      $WT_BASE_BRANCH"
+    echo
+  fi
 
   # Write to wt-common using sed
-  echo "Saving to wt-common..."
+  echo "Saving configuration..."
   sed -i.bak \
     -e "s|: \"\${WT_MAIN_REPO_ROOT:=.*}\"|: \"\${WT_MAIN_REPO_ROOT:=\"$WT_MAIN_REPO_ROOT\"}\"|" \
     -e "s|: \"\${WT_WORKTREES_BASE:=.*}\"|: \"\${WT_WORKTREES_BASE:=\"$WT_WORKTREES_BASE\"}\"|" \
@@ -180,8 +339,17 @@ migrate_repo() {
       return 1
     fi
 
-    echo "Moving $WT_ACTIVE_WORKTREE -> $WT_MAIN_REPO_ROOT ..."
-    mv "$WT_ACTIVE_WORKTREE" "$WT_MAIN_REPO_ROOT"
+    # Use a temp directory to handle nested structures (e.g., moving ~/java to ~/java/base)
+    local temp_dir="${WT_ACTIVE_WORKTREE}.wt-migrate-$$-$(date +%s)"
+
+    echo "Moving $WT_ACTIVE_WORKTREE -> $temp_dir (temporary) ..."
+    mv "$WT_ACTIVE_WORKTREE" "$temp_dir"
+
+    # Create parent directory for destination if needed
+    mkdir -p "$(dirname "$WT_MAIN_REPO_ROOT")"
+
+    echo "Moving $temp_dir -> $WT_MAIN_REPO_ROOT ..."
+    mv "$temp_dir" "$WT_MAIN_REPO_ROOT"
 
     echo "Creating symlink $WT_ACTIVE_WORKTREE -> $WT_MAIN_REPO_ROOT ..."
     ln -s "$WT_MAIN_REPO_ROOT" "$WT_ACTIVE_WORKTREE"
@@ -207,7 +375,7 @@ migrate_repo() {
 # Set up cron job for .ijwb refresh
 setup_cron_job() {
   local refresh_script="$INSTALL_DIR/lib/wt-ijwb-refresh"
-  local log_dir="$HOME/.config/wt/logs"
+  local log_dir="$HOME/.wt/logs"
   local log_file="$log_dir/ijwb-refresh.log"
   local cron_entry="0 2 * * * /bin/zsh -lc '$refresh_script' >> $log_file 2>&1"
 
@@ -341,6 +509,28 @@ main() {
   echo "Install to:  $INSTALL_DIR"
   echo
 
+  # Clean up old installation location if present
+  if [[ -d "$HOME/.config/wt" ]]; then
+    echo "Found old installation at ~/.config/wt"
+    echo
+    echo "This version uses ~/.wt/ instead."
+    echo "Your existing worktrees and code are not affected."
+    echo
+    if prompt_confirm "Remove old installation? [Y/n]" "y"; then
+      rm -rf "$HOME/.config/wt"
+      # Update shell rc files to use new path
+      for rc_file in "$HOME/.zshrc" "$HOME/.bashrc"; do
+        if [[ -f "$rc_file" ]] && grep -q '\.config/wt' "$rc_file"; then
+          sed -i.bak 's|\.config/wt|.wt|g' "$rc_file"
+          rm -f "$rc_file.bak"
+          echo "  ✓ Updated $rc_file"
+        fi
+      done
+      echo "  ✓ Removed old installation"
+    fi
+    echo
+  fi
+
   install_toolkit
   echo
 
@@ -348,7 +538,7 @@ main() {
   echo
 
   echo "════════════════════════════════════════════════════════════════════════════════"
-  echo "  Workspace Configuration"
+  echo "  Repository Setup"
   echo "════════════════════════════════════════════════════════════════════════════════"
   echo
 

--- a/lib/wt-choose
+++ b/lib/wt-choose
@@ -51,8 +51,8 @@ LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Bootstrap: source wt-common from same directory
 if [[ -f "$LIB_DIR/wt-common" ]]; then
   . "$LIB_DIR/wt-common"
-elif [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+elif [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 else
   echo "Error: Cannot find wt-common" >&2
   exit 1

--- a/lib/wt-common
+++ b/lib/wt-common
@@ -13,13 +13,14 @@
 #
 
 # Main monorepo root (where `git worktree` is managed)
-: "${WT_MAIN_REPO_ROOT:="$HOME/Development/java-master"}"
+# Default assumes a repo named "repo" - install.sh will configure the actual name
+: "${WT_MAIN_REPO_ROOT:="$HOME/.wt/repos/repo/base"}"
 
 # Base directory where new worktrees will be created by default
-: "${WT_WORKTREES_BASE:="$HOME/Development/java-worktrees"}"
+: "${WT_WORKTREES_BASE:="$HOME/.wt/repos/repo/worktrees"}"
 
 # Base directory for IntelliJ / Bazel project metadata (e.g. canonical .ijwb)
-: "${WT_IDEA_FILES_BASE:="$HOME/Development/idea-project-files"}"
+: "${WT_IDEA_FILES_BASE:="$HOME/.wt/repos/repo/idea-files"}"
 
 # Symlink path that points to the currently active worktree (for IDE integration)
 : "${WT_ACTIVE_WORKTREE:="$HOME/Development/java"}"
@@ -91,10 +92,10 @@ wt_source() {
 
   if [[ -f "$lib_dir/$script" ]]; then
     . "$lib_dir/$script"
-  elif [[ -f "$HOME/.config/wt/lib/$script" ]]; then
-    . "$HOME/.config/wt/lib/$script"
+  elif [[ -f "$HOME/.wt/lib/$script" ]]; then
+    . "$HOME/.wt/lib/$script"
   else
-    echo "Error: Cannot find $script in $lib_dir or ~/.config/wt/lib/" >&2
+    echo "Error: Cannot find $script in $lib_dir or ~/.wt/lib/" >&2
     return 1
   fi
 }

--- a/lib/wt-ijwb-refresh
+++ b/lib/wt-ijwb-refresh
@@ -28,7 +28,7 @@
 #
 # Cron Setup:
 #   # Run nightly at 2am with full shell environment, log output
-#   0 2 * * * /bin/zsh -lc '~/.config/wt/lib/wt-ijwb-refresh' >> ~/.config/wt/logs/ijwb-refresh.log 2>&1
+#   0 2 * * * /bin/zsh -lc '~/.wt/lib/wt-ijwb-refresh' >> ~/.wt/logs/ijwb-refresh.log 2>&1
 #
 # Note:
 #   The bazel query approach may include more targets than IntelliJ's native sync
@@ -47,8 +47,8 @@ BIN_DIR="$SCRIPT_DIR/../bin"
 # Bootstrap: source wt-common from lib/
 if [[ -f "$LIB_DIR/wt-common" ]]; then
   . "$LIB_DIR/wt-common"
-elif [[ -f "$HOME/.config/wt/lib/wt-common" ]]; then
-  . "$HOME/.config/wt/lib/wt-common"
+elif [[ -f "$HOME/.wt/lib/wt-common" ]]; then
+  . "$HOME/.wt/lib/wt-common"
 else
   echo "Error: Cannot find wt-common" >&2
   exit 1
@@ -59,7 +59,7 @@ fi
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # Log directory for cron runs
-LOG_DIR="${WT_LOG_DIR:-$HOME/.config/wt/logs}"
+LOG_DIR="${WT_LOG_DIR:-$HOME/.wt/logs}"
 
 # Exit codes
 EXIT_SUCCESS=0

--- a/wt.sh
+++ b/wt.sh
@@ -77,8 +77,8 @@ _wt_source_lib() {
   
   if [[ -f "$_WT_ROOT/lib/$lib" ]]; then
     . "$_WT_ROOT/lib/$lib"
-  elif [[ -f "$HOME/.config/wt/lib/$lib" ]]; then
-    . "$HOME/.config/wt/lib/$lib"
+  elif [[ -f "$HOME/.wt/lib/$lib" ]]; then
+    . "$HOME/.wt/lib/$lib"
   elif [[ "$required" != "optional" ]]; then
     echo "wt: cannot find required library: $lib" >&2
     return 1


### PR DESCRIPTION
Replace hardcoded java-monorepo defaults with a user-centric flow that:
  - Asks which repository to manage first
  - Auto-detects default branch from origin/HEAD or main/master
  - Derives all paths from repo location (e.g., myrepo -> myrepo-master, myrepo-worktrees)
  - Shows derived config and allows customization

```
════════════════════════════════════════════════════════════════════════════════
  Repository Setup
════════════════════════════════════════════════════════════════════════════════

Which repository do you want to manage with worktrees?

Enter the path to your existing git repository.
Example: ~/Development/myrepo

Repository path: ~/Development/java             <--- user input

Detected repository:
  Path:   /Users/guodong/Development/java
  Remote: [remote-ssh-path]
  Branch: master (default branch)

Derived configuration:

  The worktree toolkit will set up the following structure:

  Active symlink:      /Users/guodong/Development/java
     Your IDE opens this path. It's a symlink that can point to any worktree.

  Main repository:     /Users/guodong/Development/java-master
     Your current repo will be moved here (the "master" worktree).

  Worktrees directory: /Users/guodong/Development/java-worktrees
     New worktrees will be created here.

  IntelliJ metadata:   /Users/guodong/.config/wt/idea-files/java
     Shared .ijwb files for instant project switching.

  Default branch:      master
     Used when creating new worktrees.

Use this configuration? [Y/n] n               <--- user input

You can customize each value. Press Enter to keep the default.

Active symlink path [/Users/guodong/Development/java]:
...
```