### PR TITLE
Add branch name resolution and tab completion

### DIFF
--- a/bin/wt-cd
+++ b/bin/wt-cd
@@ -46,15 +46,16 @@ wt_source wt-choose
 
 usage() {
   cat >&2 <<EOF
-Usage: $(basename "$0") [worktree-path]
+Usage: $(basename "$0") [worktree-path|branch-name]
 
 Modes:
-  $(basename "$0")              # Interactive: pick worktree from menu
-  $(basename "$0") <worktree>   # Output validated path directly
+  $(basename "$0")                          # Interactive: pick worktree from menu
+  $(basename "$0") <worktree-path|branch>   # Output validated path directly
 
 Typical Usage:
-  cd "\$(wt-cd)"          # Navigate to selected worktree
-  cd "\$(wt-cd /path)"    # Navigate with validation
+  cd "\$(wt-cd)"                  # Navigate to selected worktree
+  cd "\$(wt-cd /path)"            # Navigate with validation
+  cd "\$(wt-cd feature/branch)"   # Navigate by branch name
 
 Shell Integration:
   Add to your shell config:
@@ -87,18 +88,7 @@ fi
 if [[ -z "$TARGET_WORKTREE" ]]; then
   TARGET_WORKTREE="$(select_git_worktree)" || exit 1
 else
-  # Validate provided worktree path exists
-  if [[ ! -d "$TARGET_WORKTREE" ]]; then
-    error "Worktree path does not exist: $TARGET_WORKTREE"
-    exit 1
-  fi
-  # Normalize to absolute path
-  TARGET_WORKTREE="$(cd "$TARGET_WORKTREE" && pwd)"
-  # Validate it's a git worktree
-  if ! git -C "$TARGET_WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    error "$TARGET_WORKTREE is not a git repository or worktree"
-    exit 1
-  fi
+  TARGET_WORKTREE="$(wt_resolve_and_validate "$TARGET_WORKTREE")" || exit 1
 fi
 
 # Output the path (only thing that goes to stdout)

--- a/bin/wt-remove
+++ b/bin/wt-remove
@@ -51,16 +51,16 @@ fi
 wt_source wt-choose
 
 usage() {
-  echo "Usage: $(basename "$0") [-y|--yes] [--merged] [worktree-path]"
+  echo "Usage: $(basename "$0") [-y|--yes] [--merged] [worktree-path|branch-name]"
   echo
   echo "Options:"
   echo "  -y, --yes           Skip confirmation prompt (unless uncommitted changes exist)"
   echo "  --merged            Remove all worktrees whose branches are merged into $WT_BASE_BRANCH"
   echo
   echo "Modes:"
-  echo "  $(basename "$0")                     # Interactive: pick worktree to remove"
-  echo "  $(basename "$0") <worktree-path>     # Remove specified worktree (with confirmation)"
-  echo "  $(basename "$0") --merged            # Remove all worktrees with merged branches"
+  echo "  $(basename "$0")                          # Interactive: pick worktree to remove"
+  echo "  $(basename "$0") <worktree-path|branch>   # Remove specified worktree (with confirmation)"
+  echo "  $(basename "$0") --merged                 # Remove all worktrees with merged branches"
 }
 
 TARGET_WORKTREE=""
@@ -213,13 +213,7 @@ if [[ -z "$TARGET_WORKTREE" ]]; then
   echo
   TARGET_WORKTREE="$(select_git_worktree exclude_main)" || exit 1
 else
-  # Validate provided worktree path exists
-  if [[ ! -d "$TARGET_WORKTREE" ]]; then
-    error "Worktree path does not exist: $TARGET_WORKTREE"
-    exit 1
-  fi
-  # Normalize to absolute path
-  TARGET_WORKTREE="$(cd "$TARGET_WORKTREE" && pwd)"
+  TARGET_WORKTREE="$(wt_resolve_and_validate "$TARGET_WORKTREE")" || exit 1
 fi
 
 # Safety check: don't remove the main repo

--- a/bin/wt-switch
+++ b/bin/wt-switch
@@ -53,11 +53,11 @@ fi
 wt_source wt-choose
 
 usage() {
-  echo "Usage: $(basename "$0") [worktree_path]"
+  echo "Usage: $(basename "$0") [worktree-path|branch-name]"
   echo
   echo "Modes:"
-  echo "  $(basename "$0")              # Interactive: pick worktree from menu"
-  echo "  $(basename "$0") <worktree>   # Non-interactive: switch to specified worktree"
+  echo "  $(basename "$0")                          # Interactive: pick worktree from menu"
+  echo "  $(basename "$0") <worktree-path|branch>   # Non-interactive: switch to specified worktree"
 }
 
 TARGET_WORKTREE=""
@@ -102,18 +102,7 @@ fi
 if [[ -z "$TARGET_WORKTREE" ]]; then
   TARGET_WORKTREE="$(select_git_worktree)" || exit 1
 else
-  # Validate provided worktree path exists
-  if [[ ! -d "$TARGET_WORKTREE" ]]; then
-    error "Worktree path does not exist: $TARGET_WORKTREE"
-    exit 1
-  fi
-  # Normalize to absolute path
-  TARGET_WORKTREE="$(cd "$TARGET_WORKTREE" && pwd)"
-  # Validate it's a git worktree
-  if ! git -C "$TARGET_WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    error "$TARGET_WORKTREE is not a git repository or worktree"
-    exit 1
-  fi
+  TARGET_WORKTREE="$(wt_resolve_and_validate "$TARGET_WORKTREE")" || exit 1
 fi
 
 mkdir -p "$(dirname "$LINK_PATH")"

--- a/completion/wt.bash
+++ b/completion/wt.bash
@@ -66,34 +66,6 @@ _wt_branch_list() {
   git -C "$repo" branch --format='%(refname:short)' 2>/dev/null
 }
 
-# --- Helper: get worktree list from resolved repo (excluding main repo) ---
-_wt_worktree_list() {
-  local repo main_repo_abs
-  repo="$(_wt_resolve_repo)"
-
-  [[ -z "$repo" ]] && return 0
-
-  # Get absolute path of main repo for exclusion
-  if [[ -n "${WT_MAIN_REPO_ROOT:-}" ]]; then
-    main_repo_abs="$(cd "$WT_MAIN_REPO_ROOT" 2>/dev/null && pwd)"
-  else
-    main_repo_abs=""
-  fi
-
-  git -C "$repo" worktree list --porcelain 2>/dev/null | while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        local wt="${line#worktree }"
-        local wt_abs
-        wt_abs="$(cd "$wt" 2>/dev/null && pwd)"
-        # Exclude main repo from list
-        if [[ -z "$main_repo_abs" || "$wt_abs" != "$main_repo_abs" ]]; then
-          printf '%s\n' "$wt_abs"
-        fi
-        ;;
-    esac
-  done
-}
 
 # ====================================================================================
 #  PATH 1: FZF is available → FZF-powered completion for wt-add first argument
@@ -206,58 +178,43 @@ else
 
 fi
 
-# --- Completion for wt-switch: worktree paths only ---
 _wt_switch_complete() {
   local cur
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
 
-  local worktrees
-  worktrees="$(_wt_worktree_list)"
-
-  # Handle paths with spaces correctly
-  if [[ -n "$worktrees" ]]; then
+  local branches
+  branches="$(wt_worktree_branch_list)"
+  if [[ -n "$branches" ]]; then
     local IFS=$'\n'
-    compopt -o filenames 2>/dev/null
-    COMPREPLY+=( $(compgen -W "$worktrees" -- "$cur") )
+    COMPREPLY+=( $(compgen -W "$branches" -- "$cur") )
   fi
-  COMPREPLY+=( $(compgen -d -- "$cur") )
 }
 
-# --- Completion for wt-remove: worktree paths only (main repo excluded) ---
 _wt_remove_complete() {
   local cur
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
 
-  local worktrees
-  worktrees="$(_wt_worktree_list)"
-
-  # Handle paths with spaces correctly
-  if [[ -n "$worktrees" ]]; then
+  local branches
+  branches="$(wt_worktree_branch_list exclude_main)"
+  if [[ -n "$branches" ]]; then
     local IFS=$'\n'
-    compopt -o filenames 2>/dev/null
-    COMPREPLY+=( $(compgen -W "$worktrees" -- "$cur") )
+    COMPREPLY+=( $(compgen -W "$branches" -- "$cur") )
   fi
-  COMPREPLY+=( $(compgen -d -- "$cur") )
 }
 
-# --- Completion for wt-cd: worktree paths only ---
 _wt_cd_complete() {
   local cur
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
 
-  local worktrees
-  worktrees="$(_wt_worktree_list)"
-
-  # Handle paths with spaces correctly
-  if [[ -n "$worktrees" ]]; then
+  local branches
+  branches="$(wt_worktree_branch_list)"
+  if [[ -n "$branches" ]]; then
     local IFS=$'\n'
-    compopt -o filenames 2>/dev/null
-    COMPREPLY+=( $(compgen -W "$worktrees" -- "$cur") )
+    COMPREPLY+=( $(compgen -W "$branches" -- "$cur") )
   fi
-  COMPREPLY+=( $(compgen -d -- "$cur") )
 }
 
 # --- Wire up completion functions (only if commands exist on PATH) ---

--- a/completion/wt.zsh
+++ b/completion/wt.zsh
@@ -55,32 +55,6 @@ _wt_branch_list() {
   git -C "$repo" branch --format='%(refname:short)' 2>/dev/null
 }
 
-# --- Helper: get worktree paths from resolved repo (excluding main repo) ---
-_wt_worktree_list() {
-  local repo main_repo_abs
-  repo=$(_wt_resolve_repo) || return
-
-  # Get absolute path of main repo for exclusion
-  if [[ -n ${WT_MAIN_REPO_ROOT:-} ]]; then
-    main_repo_abs="$(cd "$WT_MAIN_REPO_ROOT" 2>/dev/null && pwd)"
-  else
-    main_repo_abs=""
-  fi
-
-  git -C "$repo" worktree list --porcelain 2>/dev/null | while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        local wt="${line#worktree }"
-        local wt_abs="$(cd "$wt" 2>/dev/null && pwd)"
-        # Exclude main repo from list
-        if [[ -z "$main_repo_abs" || "$wt_abs" != "$main_repo_abs" ]]; then
-          print -r -- "$wt_abs"
-        fi
-        ;;
-    esac
-  done
-}
-
 # -------------------------------------------------------------------
 #  PATH 1: FZF is available → use FZF-powered completion for wt-add
 # -------------------------------------------------------------------
@@ -148,7 +122,7 @@ if (( $+commands[fzf] )); then
   # Bind Ctrl+X Ctrl+A to always trigger FZF-based branch picker
   bindkey '^X^A' wt_fzf_branch_complete
 
-  # Completion for wt-switch: worktree paths only
+  # Completion for wt-switch: branch names
   _wt_switch() {
     local context state
     typeset -A opt_args
@@ -158,19 +132,17 @@ if (( $+commands[fzf] )); then
 
     case "$state" in
       worktree)
-        local -a worktrees
-        worktrees=(${(f)$(_wt_worktree_list)})
+        local -a branches
+        branches=("${(f)$(wt_worktree_branch_list)}")
 
-        if (( ${#worktrees[@]} > 0 )); then
-          _describe 'worktrees' worktrees || _files -/
-        else
-          _files -/
+        if (( ${#branches[@]} > 0 )); then
+          _describe 'branch names' branches
         fi
         ;;
     esac
   }
 
-  # Completion for wt-remove: worktree paths only (main repo excluded)
+  # Completion for wt-remove: branch names (main repo excluded)
   _wt_remove() {
     local context state
     typeset -A opt_args
@@ -180,19 +152,17 @@ if (( $+commands[fzf] )); then
 
     case "$state" in
       worktree)
-        local -a worktrees
-        worktrees=(${(f)$(_wt_worktree_list)})
+        local -a branches
+        branches=("${(f)$(wt_worktree_branch_list exclude_main)}")
 
-        if (( ${#worktrees[@]} > 0 )); then
-          _describe 'worktrees' worktrees || _files -/
-        else
-          _files -/
+        if (( ${#branches[@]} > 0 )); then
+          _describe 'branch names' branches
         fi
         ;;
     esac
   }
 
-  # Completion for wt-cd: worktree paths only
+  # Completion for wt-cd: branch names
   _wt_cd() {
     local context state
     typeset -A opt_args
@@ -202,13 +172,11 @@ if (( $+commands[fzf] )); then
 
     case "$state" in
       worktree)
-        local -a worktrees
-        worktrees=(${(f)$(_wt_worktree_list)})
+        local -a branches
+        branches=("${(f)$(wt_worktree_branch_list)}")
 
-        if (( ${#worktrees[@]} > 0 )); then
-          _describe 'worktrees' worktrees || _files -/
-        else
-          _files -/
+        if (( ${#branches[@]} > 0 )); then
+          _describe 'branch names' branches
         fi
         ;;
     esac
@@ -240,7 +208,7 @@ else
     case "$state" in
       branch|first)
         local -a branches
-        branches=(${(f)$(_wt_branch_list)})
+        branches=("${(f)$(_wt_branch_list)}")
 
         if (( ${#branches[@]} > 0 )); then
           _describe 'branches' branches || _files
@@ -251,7 +219,7 @@ else
     esac
   }
 
-  # Completion for wt-switch: worktree paths only
+  # Completion for wt-switch: branch names
   _wt_switch() {
     local context state
     typeset -A opt_args
@@ -261,19 +229,17 @@ else
 
     case "$state" in
       worktree)
-        local -a worktrees
-        worktrees=(${(f)$(_wt_worktree_list)})
+        local -a branches
+        branches=("${(f)$(wt_worktree_branch_list)}")
 
-        if (( ${#worktrees[@]} > 0 )); then
-          _describe 'worktrees' worktrees || _files -/
-        else
-          _files -/
+        if (( ${#branches[@]} > 0 )); then
+          _describe 'branch names' branches
         fi
         ;;
     esac
   }
 
-  # Completion for wt-remove: worktree paths only (main repo excluded)
+  # Completion for wt-remove: branch names (main repo excluded)
   _wt_remove() {
     local context state
     typeset -A opt_args
@@ -283,19 +249,17 @@ else
 
     case "$state" in
       worktree)
-        local -a worktrees
-        worktrees=(${(f)$(_wt_worktree_list)})
+        local -a branches
+        branches=("${(f)$(wt_worktree_branch_list exclude_main)}")
 
-        if (( ${#worktrees[@]} > 0 )); then
-          _describe 'worktrees' worktrees || _files -/
-        else
-          _files -/
+        if (( ${#branches[@]} > 0 )); then
+          _describe 'branch names' branches
         fi
         ;;
     esac
   }
 
-  # Completion for wt-cd: worktree paths only
+  # Completion for wt-cd: branch names
   _wt_cd() {
     local context state
     typeset -A opt_args
@@ -305,13 +269,11 @@ else
 
     case "$state" in
       worktree)
-        local -a worktrees
-        worktrees=(${(f)$(_wt_worktree_list)})
+        local -a branches
+        branches=("${(f)$(wt_worktree_branch_list)}")
 
-        if (( ${#worktrees[@]} > 0 )); then
-          _describe 'worktrees' worktrees || _files -/
-        else
-          _files -/
+        if (( ${#branches[@]} > 0 )); then
+          _describe 'branch names' branches
         fi
         ;;
     esac

--- a/lib/wt-common
+++ b/lib/wt-common
@@ -103,6 +103,90 @@ wt_source() {
 # Git helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
+# Resolve a worktree identifier (path or branch name) to an absolute worktree path.
+# Tries:
+#   1. Filesystem path (directory must exist) — preserves existing behavior
+#   2. Exact branch name match via `git worktree list --porcelain`
+# Note: Detached HEAD worktrees cannot be resolved by branch name; use the path instead.
+# Usage: wt_resolve_worktree <identifier>
+# Outputs: absolute path on stdout
+# Returns: 0 on success, 1 if not found
+wt_resolve_worktree() {
+  local identifier="$1"
+
+  # 1) Try as filesystem path
+  if [[ -d "$identifier" ]]; then
+    (cd "$identifier" && pwd)
+    return 0
+  fi
+
+  # 2) Try as exact branch name
+  local wt_path="" branch=""
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        wt_path="${line#worktree }"
+        ;;
+      branch\ *)
+        branch="${line#branch refs/heads/}"
+        if [[ "$branch" == "$identifier" ]]; then
+          (cd "$wt_path" 2>/dev/null && pwd) && return 0
+        fi
+        ;;
+    esac
+  done < <(git -C "$WT_MAIN_REPO_ROOT" worktree list --porcelain 2>/dev/null)
+
+  return 1
+}
+
+# Resolve a worktree identifier and validate it's a git worktree.
+# Combines wt_resolve_worktree + git-worktree validation.
+# Usage: wt_resolve_and_validate <identifier>
+# Outputs: absolute path on stdout
+# Returns: 0 on success, 1 on failure (with error message on stderr)
+wt_resolve_and_validate() {
+  local identifier="$1"
+  local resolved
+  if ! resolved="$(wt_resolve_worktree "$identifier")"; then
+    error "Worktree not found (not a valid path or branch name): $identifier"
+    return 1
+  fi
+  if ! git -C "$resolved" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    error "$resolved is not a git repository or worktree"
+    return 1
+  fi
+  printf '%s\n' "$resolved"
+}
+
+# List branch names of active worktrees.
+# Usage: wt_worktree_branch_list [exclude_main]
+# Outputs: one branch name per line to stdout
+# Note: Detached HEAD worktrees are excluded (no branch name to emit).
+wt_worktree_branch_list() {
+  local exclude_main="${1:-}"
+  local main_repo_abs=""
+
+  if [[ "$exclude_main" == "exclude_main" && -n "${WT_MAIN_REPO_ROOT:-}" ]]; then
+    main_repo_abs="$(cd "$WT_MAIN_REPO_ROOT" 2>/dev/null && pwd)"
+  fi
+
+  local wt_path="" wt_abs="" branch=""
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        wt_path="${line#worktree }"
+        ;;
+      branch\ *)
+        wt_abs="$(cd "$wt_path" 2>/dev/null && pwd)" || continue
+        if [[ -z "$main_repo_abs" || "$wt_abs" != "$main_repo_abs" ]]; then
+          branch="${line#branch refs/heads/}"
+          printf '%s\n' "$branch"
+        fi
+        ;;
+    esac
+  done < <(git -C "$WT_MAIN_REPO_ROOT" worktree list --porcelain 2>/dev/null)
+}
+
 # Get the currently linked worktree path (resolves symlink)
 # Usage: wt_get_linked_worktree
 # Outputs: absolute path to linked worktree, or empty if none

--- a/lib/wt-completion
+++ b/lib/wt-completion
@@ -36,13 +36,15 @@ if [[ -n "$ZSH_VERSION" ]]; then
           branches=($(git branch -a 2>/dev/null | sed 's/^[* ]*//' | sed 's|remotes/origin/||'))
           _describe 'branch' branches
           ;;
-        switch|remove|cd)
-          # Complete worktree paths
-          local worktrees
-          if [[ -n "$WT_MAIN_REPO_ROOT" ]] && [[ -d "$WT_MAIN_REPO_ROOT" ]]; then
-            worktrees=($(git -C "$WT_MAIN_REPO_ROOT" worktree list --porcelain 2>/dev/null | grep '^worktree ' | cut -d' ' -f2-))
-            _describe 'worktree' worktrees
-          fi
+        switch|cd)
+          local -a branches
+          branches=("${(f)$(wt_worktree_branch_list)}")
+          (( ${#branches[@]} > 0 )) && _describe 'branch names' branches
+          ;;
+        remove)
+          local -a branches
+          branches=("${(f)$(wt_worktree_branch_list exclude_main)}")
+          (( ${#branches[@]} > 0 )) && _describe 'branch names' branches
           ;;
         ijwb-import)
           # First arg: source directory or target worktree
@@ -91,11 +93,20 @@ if [[ -n "$BASH_VERSION" ]]; then
           branches=$(git branch -a 2>/dev/null | sed 's/^[* ]*//' | sed 's|remotes/origin/||')
           COMPREPLY=($(compgen -W "$branches" -- "$cur"))
           ;;
-        switch|remove|cd)
-          local worktrees
-          if [[ -n "$WT_MAIN_REPO_ROOT" ]] && [[ -d "$WT_MAIN_REPO_ROOT" ]]; then
-            worktrees=$(git -C "$WT_MAIN_REPO_ROOT" worktree list --porcelain 2>/dev/null | grep '^worktree ' | cut -d' ' -f2-)
-            COMPREPLY=($(compgen -W "$worktrees" -- "$cur"))
+        switch|cd)
+          local branches
+          branches="$(wt_worktree_branch_list)"
+          if [[ -n "$branches" ]]; then
+            local IFS=$'\n'
+            COMPREPLY+=($(compgen -W "$branches" -- "$cur"))
+          fi
+          ;;
+        remove)
+          local branches
+          branches="$(wt_worktree_branch_list exclude_main)"
+          if [[ -n "$branches" ]]; then
+            local IFS=$'\n'
+            COMPREPLY+=($(compgen -W "$branches" -- "$cur"))
           fi
           ;;
         ijwb-import)


### PR DESCRIPTION
Allow wt-switch, wt-remove, and wt-cd to accept branch names in addition to paths. Tab completion now shows branch names instead of full worktree paths.