### PR TITLE
fix(setup): prevent clobbered `cd` related issues e.g. Zoxide

### DIFF
--- a/wt.sh
+++ b/wt.sh
@@ -61,12 +61,12 @@ _wt_resolve_root() {
   local source="$(_wt_get_script_path)"
   # Resolve symlinks to find the real location
   while [[ -L "$source" ]]; do
-    local dir="$(cd -P "$(dirname "$source")" && pwd)"
+    local dir="$(command cd -P "$(dirname "$source")" && pwd)"
     source="$(readlink "$source")"
     # If source is relative, resolve it relative to the symlink's directory
     [[ "$source" != /* ]] && source="$dir/$source"
   done
-  cd -P "$(dirname "$source")" && pwd
+  command cd -P "$(dirname "$source")" && pwd
 }
 
 # helper for sourcing a library file from lib/ directory


### PR DESCRIPTION
👋 Some CLI tools like `zoxide` either enhances and/or clobbers the `cd` command in a way that interferes with other setup scripts that rely on `cd` for their own inits early in a shell's init.

This is usually fixable by guaranteeing load order in `~/.zshrc`, but IMO a more robust solution is to ensure we call the system's `cd` command by using `command cd` instead, especially in the context of `_wt_resolve_root` which is expected to be called during shell init to bootstrap `wt`.