### PR TITLE
fix(zsh): use builtin cd instead of command cd in _wt_resolve_root

### DIFF
--- a/wt.sh
+++ b/wt.sh
@@ -57,14 +57,16 @@ _wt_ensure_sourced() {
 _wt_resolve_root() {
   local source="$_WT_SCRIPT_PATH"
   # Resolve symlinks to find the real location
+  # Note: uses `builtin cd` instead of `command cd` because zsh's `command cd`
+  # silently fails to change directories (exits 0 but stays in CWD)
   while [[ -L "$source" ]]; do
     local dir
-    dir="$(command cd -P "$(dirname "$source")" && pwd)"
+    dir="$(builtin cd -P "$(dirname "$source")" && pwd)"
     source="$(readlink "$source")"
     # If source is relative, resolve it relative to the symlink's directory
     [[ "$source" != /* ]] && source="$dir/$source"
   done
-  command cd -P "$(dirname "$source")" && pwd
+  builtin cd -P "$(dirname "$source")" && pwd
 }
 
 # helper for sourcing a library file from lib/ directory


### PR DESCRIPTION
zsh's `command cd` exits 0 but silently fails to change directories, causing _WT_ROOT to resolve to the shell's startup CWD instead of the actual wt.sh location. This made `wt cd` fail when the terminal was opened from a directory other than ~/Development/wt.