### PR TITLE
Fix wt-metadata-refresh failing on .bazelproject with commented directories

### DIFF
--- a/lib/wt-metadata-refresh
+++ b/lib/wt-metadata-refresh
@@ -188,7 +188,7 @@ parse_bazelproject_directories() {
   awk '
     /^directories:/ { in_dirs=1; next }
     /^[a-z_]+:/ { in_dirs=0 }
-    in_dirs && /^[[:space:]]+[^#]/ { gsub(/^[[:space:]]+/, ""); print }
+    in_dirs { gsub(/^[[:space:]]+/, ""); if ($0 != "" && !/^#/) print }
   ' "$bazelproject_file"
 }
 
@@ -281,17 +281,10 @@ refresh_targets_file() {
   # Run bazel query from the MAIN REPO ROOT (not project root)
   # This is important because .bazelproject directories are relative to repo root
   local query_output
-  local query_exit_code=0
-
   query_output=$(
     cd "$WT_MAIN_REPO_ROOT" 2>/dev/null && \
-    bazel query "$full_query" --output=label 2>/dev/null | sort
-  ) || query_exit_code=$?
-
-  if [[ $query_exit_code -ne 0 ]]; then
-    warn "  Bazel query failed for $project_name (exit code: $query_exit_code)"
-    return 1
-  fi
+    { bazel query "$full_query" --output=label --keep_going 2>/dev/null || true; } | sort
+  )
 
   if [[ -z "$query_output" ]]; then
     warn "  Bazel query returned empty results for $project_name"


### PR DESCRIPTION
## Why
`wt-metadata-refresh` always fails when the `.bazelproject` file contains commented-out directories (e.g. `# ca`, `# deposits`).

## What
- Fix awk regex that failed to filter commented lines — `[^#]` matched the second space character instead of the `#`, leaking invalid paths like `//# ca/...` into the bazel query
- Use `--keep_going` and `|| true` so directories without BUILD files (e.g. `.github`, `.hooks`) don't kill the entire query via `pipefail`

## Risk Assessment
Low — only affects the metadata refresh script, no production services.

## Testing

**Discovery:** Running `wt-metadata-refresh` failed with `Bazel query failed for base (exit code: 2)`. The stderr was suppressed (`2>/dev/null`), so the root cause wasn't visible.

**Root cause analysis:**
1. Ran the awk parser in isolation and found commented lines like `  # ca` were passing through:
   ```
   printf '  # ca\n' | awk '/^[[:space:]]+[^#]/ { print "MATCH" }'
   # Output: MATCH
   ```
   The regex `[[:space:]]+` only consumed one space, then `[^#]` matched the second space — not the `#`.

2. Confirmed the generated query included invalid paths like `//# ca/...`, causing bazel query to fail entirely.

3. After fixing the awk regex, bazel query still failed because `.github` and `.hooks` have no BUILD files:
   ```
   bazel query "kind('.*', //.github/... + //account-status/...)" --output=label
   # ERROR: no targets found beneath '.github'  (exit code 7)
   ```

**Validation:** After both fixes, ran `wt-metadata-refresh` successfully — refreshed 14,949 targets and re-exported 53 metadata directories to the vault.

Generated with Amp